### PR TITLE
Replace punctuation with space in pre_slug

### DIFF
--- a/thepysec/lia/strings.py
+++ b/thepysec/lia/strings.py
@@ -115,7 +115,7 @@ def pre_slug(s):
             r" \1 ",
             unidecode(
                 s.translate(
-                    str.maketrans(" ", "", "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
+                    str.maketrans(" ", "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
                 ).lower()
             ),
         ).split()

--- a/thepysec/lia/strings.py
+++ b/thepysec/lia/strings.py
@@ -109,14 +109,46 @@ def pre_slug(s):
     pros: Keeps numbers together adding space only between numbers and letters.
     cons: Almost double the time of fast_pre_slug, no space between punctuation and letters.
     """
+    punctuation = {
+        "!": " ",
+        '"': " ",
+        "#": " ",
+        "$": " ",
+        "%": " ",
+        "&": " ",
+        "'": " ",
+        "(": " ",
+        ")": " ",
+        "*": " ",
+        "+": " ",
+        ",": " ",
+        "-": " ",
+        ".": " ",
+        "/": " ",
+        ":": " ",
+        ";": " ",
+        "<": " ",
+        "=": " ",
+        ">": " ",
+        "?": " ",
+        "@": " ",
+        "[": " ",
+        "\\": " ",
+        "]": " ",
+        "^": " ",
+        "_": " ",
+        "`": " ",
+        "{": " ",
+        "|": " ",
+        "}": " ",
+        "~": " ",
+    }    
     return " ".join(
         re.sub(
             r"([0-9]+(\.[0-9]+)?)",
             r" \1 ",
             unidecode(
-                s.translate(
-                    str.maketrans(" ", "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
-                ).lower()
+                s.translate(str.maketrans(punctuation)).lower()
             ),
         ).split()
     )

--- a/thepysec/lia/strings.py
+++ b/thepysec/lia/strings.py
@@ -38,7 +38,7 @@ def fast_pre_slug(lia_string):
     """
     * Decode string to ASCII
     * Lower case for all letters
-    * Replace punctuation with space
+    * Replace punctuation with space (punctuation in a valid input, has semantic meaning)
     * Add space around numbers
     * Remove extra spaces
     8μs from: 'tr4e, 5435 (bili#go)' to 'tr 4 e 5 4 3 5 bili go'
@@ -102,7 +102,7 @@ def pre_slug(s):
     """
     * Decode string to ASCII
     * Lower case for all letters
-    * Remove punctuation
+    * Replace punctuation with a space (punctuation in a valid input, has semantic meaning)
     * Add space between numbers and letters
     * Remove extra spaces
     13.5μs from: 'tr4e, 5435 (bili#go)' to 'tr 4 e 5435 biligo'
@@ -115,7 +115,7 @@ def pre_slug(s):
             r" \1 ",
             unidecode(
                 s.translate(
-                    str.maketrans("", "", "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
+                    str.maketrans(" ", "", "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~")
                 ).lower()
             ),
         ).split()

--- a/thepysec/lia/tests/test_strings.py
+++ b/thepysec/lia/tests/test_strings.py
@@ -47,7 +47,7 @@ def test_django_pop_whitespace():
 
 def test_pre_slug():
     raw_slug = 'tr4e, 5435 (bili#go)'
-    assert strings.pre_slug(raw_slug) == 'tr 4 e 5435 biligo'
+    assert strings.pre_slug(raw_slug) == 'tr 4 e 5435 bili go'
 
 
 def test_fast_pre_slug():


### PR DESCRIPTION
Considering that pre_slug is not a validator but a slug constructor, in a valid input punctuation has a semantic meaning. Therefore it is a better choice to replace it with a space rather than eliminating it.